### PR TITLE
Scheduler/Entity Manager/Routine/Render Graph Updates

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/ClientBase.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/ClientBase.java
@@ -3,6 +3,7 @@ package com.terminalvelocitycabbage.engine.client;
 import com.github.simplenet.Client;
 import com.terminalvelocitycabbage.engine.Entrypoint;
 import com.terminalvelocitycabbage.engine.client.renderer.RendererBase;
+import com.terminalvelocitycabbage.engine.client.renderer.graph.RenderGraph;
 import com.terminalvelocitycabbage.engine.client.window.WindowManager;
 import com.terminalvelocitycabbage.engine.ecs.Manager;
 import com.terminalvelocitycabbage.engine.event.EventDispatcher;
@@ -12,6 +13,7 @@ import com.terminalvelocitycabbage.engine.mod.ModManager;
 import com.terminalvelocitycabbage.engine.networking.*;
 import com.terminalvelocitycabbage.engine.registry.Registry;
 import com.terminalvelocitycabbage.engine.util.TickManager;
+import com.terminalvelocitycabbage.engine.util.touples.Pair;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -24,7 +26,7 @@ public abstract class ClientBase extends Entrypoint implements NetworkedSide {
 
     //Game loop stuff
     private WindowManager windowManager;
-    private Registry<Class<? extends RendererBase>> rendererRegistry;
+    private Registry<Pair<Class<? extends RendererBase>, RenderGraph>> rendererRegistry;
     private TickManager tickManager;
     private Manager manager;
 
@@ -175,7 +177,7 @@ public abstract class ClientBase extends Entrypoint implements NetworkedSide {
         return manager;
     }
 
-    public Registry<Class<? extends RendererBase>> getRendererRegistry() {
+    public Registry<Pair<Class<? extends RendererBase>, RenderGraph>> getRendererRegistry() {
         return rendererRegistry;
     }
 

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/ClientBase.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/ClientBase.java
@@ -4,6 +4,7 @@ import com.github.simplenet.Client;
 import com.terminalvelocitycabbage.engine.Entrypoint;
 import com.terminalvelocitycabbage.engine.client.renderer.RendererBase;
 import com.terminalvelocitycabbage.engine.client.window.WindowManager;
+import com.terminalvelocitycabbage.engine.ecs.Manager;
 import com.terminalvelocitycabbage.engine.event.EventDispatcher;
 import com.terminalvelocitycabbage.engine.filesystem.GameFileSystem;
 import com.terminalvelocitycabbage.engine.mod.Mod;
@@ -25,6 +26,7 @@ public abstract class ClientBase extends Entrypoint implements NetworkedSide {
     private WindowManager windowManager;
     private Registry<Class<? extends RendererBase>> rendererRegistry;
     private TickManager tickManager;
+    private Manager manager;
 
     //Networking stuff
     private Client client;
@@ -42,6 +44,7 @@ public abstract class ClientBase extends Entrypoint implements NetworkedSide {
         super(namespace);
         instance = this;
         tickManager = new TickManager(ticksPerSecond);
+        manager = new Manager();
         eventDispatcher = new EventDispatcher();
         eventDispatcher.addPublisher(getNamespace(), this);
         modManager = new ModManager();
@@ -166,6 +169,10 @@ public abstract class ClientBase extends Entrypoint implements NetworkedSide {
 
     public GameFileSystem getFileSystem() {
         return fileSystem;
+    }
+
+    public Manager getManager() {
+        return manager;
     }
 
     public Registry<Class<? extends RendererBase>> getRendererRegistry() {

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/ClientBase.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/ClientBase.java
@@ -12,6 +12,7 @@ import com.terminalvelocitycabbage.engine.mod.Mod;
 import com.terminalvelocitycabbage.engine.mod.ModManager;
 import com.terminalvelocitycabbage.engine.networking.*;
 import com.terminalvelocitycabbage.engine.registry.Registry;
+import com.terminalvelocitycabbage.engine.scheduler.Scheduler;
 import com.terminalvelocitycabbage.engine.util.TickManager;
 import com.terminalvelocitycabbage.engine.util.touples.Pair;
 
@@ -29,6 +30,7 @@ public abstract class ClientBase extends Entrypoint implements NetworkedSide {
     private Registry<Pair<Class<? extends RendererBase>, RenderGraph>> rendererRegistry;
     private TickManager tickManager;
     private Manager manager;
+    private Scheduler scheduler;
 
     //Networking stuff
     private Client client;
@@ -47,6 +49,7 @@ public abstract class ClientBase extends Entrypoint implements NetworkedSide {
         instance = this;
         tickManager = new TickManager(ticksPerSecond);
         manager = new Manager();
+        scheduler = new Scheduler();
         eventDispatcher = new EventDispatcher();
         eventDispatcher.addPublisher(getNamespace(), this);
         modManager = new ModManager();
@@ -134,7 +137,9 @@ public abstract class ClientBase extends Entrypoint implements NetworkedSide {
      * initializes the game loop
      */
     private void run() {
-        windowManager.loop();
+        while (!windowManager.loop()) {
+            update();
+        }
     }
 
     /**
@@ -151,7 +156,9 @@ public abstract class ClientBase extends Entrypoint implements NetworkedSide {
      * The code to be executed every tick
      * This is mainly used for networking tasks, most things for clients should happen every frame
      */
-    public abstract void tick();
+    public void tick() {
+        getScheduler().tick();
+    }
 
     @Override
     public void destroy() {
@@ -175,6 +182,10 @@ public abstract class ClientBase extends Entrypoint implements NetworkedSide {
 
     public Manager getManager() {
         return manager;
+    }
+
+    public Scheduler getScheduler() {
+        return scheduler;
     }
 
     public Registry<Pair<Class<? extends RendererBase>, RenderGraph>> getRendererRegistry() {

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/ClientBase.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/ClientBase.java
@@ -9,16 +9,12 @@ import com.terminalvelocitycabbage.engine.filesystem.GameFileSystem;
 import com.terminalvelocitycabbage.engine.mod.Mod;
 import com.terminalvelocitycabbage.engine.mod.ModManager;
 import com.terminalvelocitycabbage.engine.networking.*;
-import com.terminalvelocitycabbage.engine.registry.Identifier;
 import com.terminalvelocitycabbage.engine.registry.Registry;
 import com.terminalvelocitycabbage.engine.util.TickManager;
 
-import javax.swing.*;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.util.*;
-import java.util.stream.Collectors;
 
 public abstract class ClientBase extends Entrypoint implements NetworkedSide {
 

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/RendererBase.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/RendererBase.java
@@ -1,13 +1,29 @@
 package com.terminalvelocitycabbage.engine.client.renderer;
 
+import com.terminalvelocitycabbage.engine.client.renderer.graph.RenderGraph;
 import com.terminalvelocitycabbage.engine.client.window.WindowProperties;
-import com.terminalvelocitycabbage.engine.ecs.Routine;
 
 public abstract class RendererBase {
 
-    Routine renderRoutine;
+    RenderGraph renderGraph;
 
-    public abstract void init(WindowProperties properties, long windowHandle);
-    public abstract void update(WindowProperties properties, long deltaTime);
-    public abstract void destroy();
+    public RendererBase(RenderGraph renderGraph) {
+        this.renderGraph = renderGraph;
+    }
+
+    public void init(WindowProperties properties, long windowHandle) {
+
+    }
+
+    public void render(WindowProperties properties, long deltaTime) {
+        renderGraph.render(properties, deltaTime);
+    }
+
+    public void destroy() {
+
+    }
+
+    public RenderGraph getRenderGraph() {
+        return renderGraph;
+    }
 }

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/RendererBase.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/RendererBase.java
@@ -1,20 +1,13 @@
 package com.terminalvelocitycabbage.engine.client.renderer;
 
 import com.terminalvelocitycabbage.engine.client.window.WindowProperties;
+import com.terminalvelocitycabbage.engine.ecs.Routine;
 
 public abstract class RendererBase {
 
-    private int rendererId;
+    Routine renderRoutine;
 
     public abstract void init(WindowProperties properties, long windowHandle);
     public abstract void update(WindowProperties properties, long deltaTime);
     public abstract void destroy();
-
-    public int getRendererId() {
-        return rendererId;
-    }
-
-    public void setRendererId(int rendererId) {
-        this.rendererId = rendererId;
-    }
 }

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/RendererBase.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/RendererBase.java
@@ -7,7 +7,7 @@ public abstract class RendererBase {
     private int rendererId;
 
     public abstract void init(WindowProperties properties, long windowHandle);
-    public abstract void update(WindowProperties properties);
+    public abstract void update(WindowProperties properties, long deltaTime);
     public abstract void destroy();
 
     public int getRendererId() {

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/GraphNode.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/GraphNode.java
@@ -1,0 +1,6 @@
+package com.terminalvelocitycabbage.engine.client.renderer.graph;
+
+/**
+ * This is just a utility class for controlling the types of classes that can be registered to a {@link RenderGraph}.
+ */
+sealed interface GraphNode permits RenderNode, Routine {}

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/RenderGraph.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/RenderGraph.java
@@ -20,18 +20,33 @@ public class RenderGraph {
         this.graphNodes = graphNodes;
     }
 
+    /**
+     * @return a new instance of {@link RenderGraph.Builder} for use in configuring a new Render Graph.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Pauses the specified node of this renderer, when paused a node will be skipped in this graph's render pass
+     * @param nodeIdentifier the {@link Identifier} for the node that you want to resume
+     */
     public void pauseNode(Identifier nodeIdentifier) {
         graphNodes.get(nodeIdentifier).getValue0().disable();
     }
 
+    /**
+     * Resumes or "un-pauses" the specified node of this renderer
+     * @param nodeIdentifier the {@link Identifier} for the node that you want to resume
+     */
     public void resumeNode(Identifier nodeIdentifier) {
         graphNodes.get(nodeIdentifier).getValue0().enable();
     }
 
+    /**
+     * @param windowProperties The current snapshot of the calling window's properties
+     * @param deltaTime The time passed since the last frame was started
+     */
     public void render(WindowProperties windowProperties, long deltaTime) {
         graphNodes.forEach((identifier, graphNode) -> {
             if (!graphNode.getValue0().getStatus()) return;
@@ -50,10 +65,24 @@ public class RenderGraph {
             graphNodes = new HashMap<>();
         }
 
+        /**
+         * Adds a node to this render graph and automatically enables it
+         * @param identifier the {@link Identifier} that corresponds to this node of the renderGraph
+         * @param graphNode the node to be added to this graph
+         * @return this Builder (for easy changing of methods)
+         */
         public Builder addNode(Identifier identifier, Class<? extends GraphNode> graphNode) {
             return addNode(identifier, graphNode, true);
         }
 
+        /**
+         * Adds a node to this render graph and allows you to specify whether to enable it by default or not
+         * useful for nodes that don't always get used or on nodes that don't need to run on the first iteration.
+         * @param identifier the {@link Identifier} that corresponds to this node of the renderGraph
+         * @param graphNode the node to be added to this graph
+         * @param automaticallyEnable a boolean to represent if this node should be enabled or paused on initialization
+         * @return this Builder (for easy changing of methods)
+         */
         public Builder addNode(Identifier identifier, Class<? extends GraphNode> graphNode, boolean automaticallyEnable) {
             try {
                 graphNodes.put(identifier, new Pair<>(new Toggle(automaticallyEnable), ClassUtils.createInstance(graphNode)));
@@ -63,6 +92,9 @@ public class RenderGraph {
             return this;
         }
 
+        /**
+         * @return A new {@link RenderGraph} instance generated from this builder.
+         */
         public RenderGraph build() {
             return new RenderGraph(graphNodes);
         }

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/RenderGraph.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/RenderGraph.java
@@ -1,0 +1,72 @@
+package com.terminalvelocitycabbage.engine.client.renderer.graph;
+
+import com.terminalvelocitycabbage.engine.client.ClientBase;
+import com.terminalvelocitycabbage.engine.client.window.WindowProperties;
+import com.terminalvelocitycabbage.engine.debug.Log;
+import com.terminalvelocitycabbage.engine.registry.Identifier;
+import com.terminalvelocitycabbage.engine.util.ClassUtils;
+import com.terminalvelocitycabbage.engine.util.Toggle;
+import com.terminalvelocitycabbage.engine.util.touples.Pair;
+
+import javax.management.ReflectionException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RenderGraph {
+
+    private final Map<Identifier, Pair<Toggle, ? extends GraphNode>> graphNodes;
+
+    private RenderGraph(Map<Identifier, Pair<Toggle, ? extends GraphNode>> graphNodes) {
+        this.graphNodes = graphNodes;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public void pauseNode(Identifier nodeIdentifier) {
+        graphNodes.get(nodeIdentifier).getValue0().disable();
+    }
+
+    public void resumeNode(Identifier nodeIdentifier) {
+        graphNodes.get(nodeIdentifier).getValue0().enable();
+    }
+
+    public void render(WindowProperties windowProperties, long deltaTime) {
+        graphNodes.forEach((identifier, graphNode) -> {
+            if (!graphNode.getValue0().getStatus()) return;
+            switch (graphNode.getValue1()) {
+                case Routine routine -> routine.update(ClientBase.getInstance().getManager()); //We assume that the server is not rendering anything
+                case RenderNode renderNode -> renderNode.executeRenderStage(windowProperties, deltaTime);
+            }
+        });
+    }
+
+    public static class Builder {
+
+        private final Map<Identifier, Pair<Toggle, ? extends GraphNode>> graphNodes;
+
+        private Builder() {
+            graphNodes = new HashMap<>();
+        }
+
+        public Builder addNode(Identifier identifier, Class<? extends GraphNode> graphNode) {
+            return addNode(identifier, graphNode, true);
+        }
+
+        public Builder addNode(Identifier identifier, Class<? extends GraphNode> graphNode, boolean automaticallyEnable) {
+            try {
+                graphNodes.put(identifier, new Pair<>(new Toggle(automaticallyEnable), ClassUtils.createInstance(graphNode)));
+            } catch (ReflectionException e) {
+                Log.crash("Could not add node " + identifier + " to graph node " + graphNode, new RuntimeException(e));
+            }
+            return this;
+        }
+
+        public RenderGraph build() {
+            return new RenderGraph(graphNodes);
+        }
+
+    }
+
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/RenderNode.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/RenderNode.java
@@ -2,6 +2,9 @@ package com.terminalvelocitycabbage.engine.client.renderer.graph;
 
 import com.terminalvelocitycabbage.engine.client.window.WindowProperties;
 
+/**
+ * A node for an {@link RenderGraph}, specifically for executing code that draws to the screen.
+ */
 public abstract non-sealed class RenderNode implements GraphNode {
 
     public abstract void executeRenderStage(WindowProperties properties, long deltaTime);

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/RenderNode.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/RenderNode.java
@@ -1,0 +1,9 @@
+package com.terminalvelocitycabbage.engine.client.renderer.graph;
+
+import com.terminalvelocitycabbage.engine.client.window.WindowProperties;
+
+public abstract non-sealed class RenderNode implements GraphNode {
+
+    public abstract void executeRenderStage(WindowProperties properties, long deltaTime);
+
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/Routine.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/Routine.java
@@ -1,6 +1,9 @@
-package com.terminalvelocitycabbage.engine.ecs;
+package com.terminalvelocitycabbage.engine.client.renderer.graph;
 
 import com.terminalvelocitycabbage.engine.debug.Log;
+import com.terminalvelocitycabbage.engine.ecs.ComponentFilter;
+import com.terminalvelocitycabbage.engine.ecs.Manager;
+import com.terminalvelocitycabbage.engine.ecs.System;
 import com.terminalvelocitycabbage.engine.registry.Identifier;
 import com.terminalvelocitycabbage.engine.util.MutableInstant;
 import com.terminalvelocitycabbage.engine.util.Toggle;
@@ -9,7 +12,7 @@ import com.terminalvelocitycabbage.engine.util.touples.Quartet;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Routine {
+public non-sealed class Routine implements GraphNode {
 
     //This Map stores data about this managed system including:
     // - If it's enabled

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/Routine.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/graph/Routine.java
@@ -12,6 +12,10 @@ import com.terminalvelocitycabbage.engine.util.touples.Quartet;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * A node for an {@link RenderGraph}, specifically for executing a set of ECS systems.
+ * Does not have to be called by a Render Graph, can also be useful serverside to chain repeating logic.
+ */
 public non-sealed class Routine implements GraphNode {
 
     //This Map stores data about this managed system including:
@@ -25,10 +29,16 @@ public non-sealed class Routine implements GraphNode {
         this.filteredSystems = managedSystems;
     }
 
+    /**
+     * @return a new instance of {@link Routine.Builder} for use in configuring a new Render Graph.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * @param manager the ESC manager that this routine operates on, usually returned by the client or server entrypoint
+     */
     public void update(Manager manager) {
         Log.info("routine update");
         filteredSystems.forEach((id, quartet) -> {
@@ -38,10 +48,18 @@ public non-sealed class Routine implements GraphNode {
         });
     }
 
+    /**
+     * Pauses the specified node of this routine, when paused a node will be skipped in this routines next update pass
+     * @param systemIdentifier the {@link Identifier} for the node that you want to resume
+     */
     public void pauseSystem(Identifier systemIdentifier) {
         filteredSystems.get(systemIdentifier).getValue0().disable();
     }
 
+    /**
+     * Resumes or "un-pauses" the specified node of this routine
+     * @param systemIdentifier the {@link Identifier} for the node that you want to resume
+     */
     public void resumeSystem(Identifier systemIdentifier) {
         filteredSystems.get(systemIdentifier).getValue0().enable();
     }
@@ -50,14 +68,38 @@ public non-sealed class Routine implements GraphNode {
 
         Map<Identifier, Quartet<Toggle, MutableInstant, Class<? extends System>, ComponentFilter>> systems = new HashMap();
 
+        /**
+         * Adds a node to this Routine. addNode calls should be specified in the order that they should be executed.
+         * This method automatically enabled this node, and assumes that this system does not need entities filtered,
+         * useful for systems that perform logic not on entities.
+         * @param nodeIdentifier An {@link Identifier} to identify this node (useful for pausing and publishing events)
+         * @param system The system that this node executes
+         * @return this Builder for easy chaining of add nodes
+         */
         public Builder addNode(Identifier nodeIdentifier, Class<? extends System> system) {
             return addNode(nodeIdentifier, system, null, true);
         }
 
+        /**
+         * Adds a node to this Routine. addNode calls should be specified in the order that they should be executed.
+         * This method automatically enabled this node
+         * @param nodeIdentifier An {@link Identifier} to identify this node (useful for pausing and publishing events)
+         * @param system The system that this node executes
+         * @param componentFilter The component filter that filters entities to be passed to the system specified
+         * @return this Builder for easy chaining of add nodes
+         */
         public Builder addNode(Identifier nodeIdentifier, Class<? extends System> system, ComponentFilter componentFilter) {
             return addNode(nodeIdentifier, system, componentFilter, true);
         }
 
+        /**
+         * Adds a node to this Routine. addNode calls should be specified in the order that they should be executed.
+         * @param nodeIdentifier An {@link Identifier} to identify this node (useful for pausing and publishing events)
+         * @param system The system that this node executes
+         * @param componentFilter The component filter that filters entities to be passed to the system specified
+         * @param automaticallyEnable A boolean to represent if this node should be executed or paused by default
+         * @return this Builder for easy chaining of add nodes
+         */
         public Builder addNode(Identifier nodeIdentifier, Class<? extends System> system, ComponentFilter componentFilter, boolean automaticallyEnable) {
             if (systems.containsKey(nodeIdentifier)) {
                 Log.crash("Could not add system node " + nodeIdentifier + " to Routine",
@@ -67,6 +109,9 @@ public non-sealed class Routine implements GraphNode {
             return this;
         }
 
+        /**
+         * @return A new instance of {@link Routine} based on this builder configuration.
+         */
         public Routine build() {
             return new Routine(systems);
         }

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowManager.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowManager.java
@@ -34,9 +34,6 @@ public class WindowManager {
     //The (usually) active windows of this manager
     private Map<Long, WindowThread> threads = new HashMap<>();
 
-    //Increments every time a renderer is assigned, this number will be used as the BGFX identifier
-    private int renderers = 0;
-
     //Initialize this window manager (glfw)
     public void init() {
 
@@ -113,7 +110,6 @@ public class WindowManager {
         Objects.requireNonNull(glfwSetErrorCallback(null)).free();
     }
 
-
     //Create a new window in this manager
     public void createNewWindow(WindowProperties properties) {
 
@@ -157,10 +153,8 @@ public class WindowManager {
             properties.setHeight(framebufferSize.get(1));
         }
 
-        //Set the renderer id
-        properties.setRendererID(renderers++);
-        //TODO remove this
-        glfwSetWindowTitle(window, properties.getTitle() + renderers);
+        //Set the window title
+        glfwSetWindowTitle(window, properties.getTitle());
 
         //Show the window
         glfwShowWindow(window);

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowManager.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowManager.java
@@ -142,6 +142,7 @@ public class WindowManager {
         });
 
         //Center the window on the primary monitor
+        //TODO allow the createWindow method to configure this somehow
         videoMode = glfwGetVideoMode(glfwGetPrimaryMonitor());
         glfwSetWindowPos(window, (videoMode.width() - properties.getWidth()) / 2, (videoMode.height() - properties.getHeight()) / 2);
 

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowManager.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowManager.java
@@ -59,30 +59,32 @@ public class WindowManager {
         }
     }
 
+    /**
+     * @return Whether this game context should stop
+     */
     //The actual window update loop
-    public void loop() {
-        while (true) {
+    public boolean loop() {
+        //Destroy all destroyable windows before polling for events
+        windowsToDestroy.forEach(window -> {
+            System.out.println("Made it to the end of life of a window");
+            destroyWindow(window);
+            System.out.println("destroyed window " + window);
+        });
+        //Reset for the next loop
+        windowsToDestroy.clear();
 
-            //Destroy all destroyable windows before polling for events
-            windowsToDestroy.forEach(window -> {
-                System.out.println("Made it to the end of life of a window");
-                destroyWindow(window);
-                System.out.println("destroyed window " + window);
-            });
-            //Reset for the next loop
-            windowsToDestroy.clear();
+        //Poll for window events (like input or closing etc.)
+        glfwWaitEvents();
 
-            //Poll for window events (like input or closing etc.)
-            glfwWaitEvents();
+        //Don't update the threads if there is nothing to update
+        if (!hasAliveWindow()) return true;
 
-            //Don't update the threads if there is nothing to update
-            if (!hasAliveWindow()) break;
+        //Check for window close requests
+        threads.forEach((window, glfwThread) -> {
+            if (glfwWindowShouldClose(window)) glfwThread.destroyThread();
+        });
 
-            //Check for window close requests
-            threads.forEach((window, glfwThread) -> {
-                if (glfwWindowShouldClose(window)) glfwThread.destroyThread();
-            });
-        }
+        return false;
     }
 
     //Destroys this window manager and glfw context

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowProperties.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowProperties.java
@@ -10,7 +10,13 @@ public class WindowProperties {
     private String title;
 
     Identifier renderer;
-    int rendererId;
+
+    public WindowProperties() {
+        this.width = 600;
+        this.height = 400;
+        this.title = "Default Title";
+        this.renderer = null;
+    }
 
     public WindowProperties(WindowProperties properties) {
         this.width = properties.getWidth();
@@ -59,13 +65,5 @@ public class WindowProperties {
 
     public void setRenderer(Identifier renderer) {
         this.renderer = renderer;
-    }
-
-    public void setRendererID(int id) {
-        rendererId = id;
-    }
-
-    public int getRendererId() {
-        return rendererId;
     }
 }

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowThread.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowThread.java
@@ -55,6 +55,9 @@ public class WindowThread extends Thread {
             throw new RuntimeException(e);
         }
 
+        //Initialize this renderer
+        renderer.init(getProperties(), windowHandle);
+
         //swap the image in this window with the new one
         long deltaTime;
         while (!quit) {

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowThread.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowThread.java
@@ -3,6 +3,7 @@ package com.terminalvelocitycabbage.engine.client.window;
 import com.terminalvelocitycabbage.engine.client.ClientBase;
 import com.terminalvelocitycabbage.engine.client.renderer.RendererBase;
 import com.terminalvelocitycabbage.engine.util.ClassUtils;
+import com.terminalvelocitycabbage.engine.util.MutableInstant;
 import org.lwjgl.opengl.GL;
 
 import javax.management.ReflectionException;
@@ -22,6 +23,7 @@ public class WindowThread extends Thread {
     WindowProperties properties;
     //Renderer
     RendererBase rendererBase;
+    final MutableInstant rendererClock;
 
     /**
      * @param windowHandle the window pointer that points to the window managed by this thread
@@ -32,6 +34,7 @@ public class WindowThread extends Thread {
         this.quit = false;
         this.windowManager = windowManager;
         this.properties = properties;
+        this.rendererClock = MutableInstant.ofNow();
     }
 
     @Override
@@ -54,7 +57,9 @@ public class WindowThread extends Thread {
 
         //swap the image in this window with the new one
         while (!quit) {
-            rendererBase.update(getProperties());
+            long deltaTime = rendererClock.getDeltaTime();
+            rendererClock.now();
+            rendererBase.update(getProperties(), deltaTime);
             glfwSwapBuffers(windowHandle);
         }
 

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowThread.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/window/WindowThread.java
@@ -2,9 +2,10 @@ package com.terminalvelocitycabbage.engine.client.window;
 
 import com.terminalvelocitycabbage.engine.client.ClientBase;
 import com.terminalvelocitycabbage.engine.client.renderer.RendererBase;
-import com.terminalvelocitycabbage.engine.registry.Identifier;
+import com.terminalvelocitycabbage.engine.client.renderer.graph.RenderGraph;
 import com.terminalvelocitycabbage.engine.util.ClassUtils;
 import com.terminalvelocitycabbage.engine.util.MutableInstant;
+import com.terminalvelocitycabbage.engine.util.touples.Pair;
 import org.lwjgl.opengl.GL;
 
 import javax.management.ReflectionException;
@@ -50,7 +51,8 @@ public class WindowThread extends Thread {
         //Create an instance of this renderer and init it
         RendererBase renderer;
         try {
-            renderer = ClassUtils.createInstance(ClientBase.getInstance().getRendererRegistry().get(properties.getRenderer()));
+            Pair<Class<? extends RendererBase>, RenderGraph> registryPair = ClientBase.getInstance().getRendererRegistry().get(properties.getRenderer());
+            renderer = ClassUtils.createInstance(registryPair.getValue0(), registryPair.getValue1());
         } catch (ReflectionException e) {
             throw new RuntimeException(e);
         }
@@ -63,7 +65,7 @@ public class WindowThread extends Thread {
         while (!quit) {
             deltaTime = rendererClock.getDeltaTime();
             rendererClock.now();
-            renderer.update(getProperties(), deltaTime);
+            renderer.render(getProperties(), deltaTime);
             glfwSwapBuffers(windowHandle);
         }
 

--- a/src/main/java/com/terminalvelocitycabbage/engine/ecs/Manager.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/ecs/Manager.java
@@ -8,7 +8,6 @@ import com.terminalvelocitycabbage.engine.util.ClassUtils;
 import javax.management.ReflectionException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * The Manager is what any implementation should interact with to "manage" their entities components and systems.
@@ -172,7 +171,9 @@ public class Manager {
      * @param filter the filter for which you want to get matching entities
      * @return a List of entities that match the filter provided
      */
+    //TODO implement some sort of cache for common returned lists of entities by component filter and update those lists with the master list for future use
     public List<Entity> getMatchingEntities(ComponentFilter filter) {
+        if (filter == null) return Collections.emptyList();
         return filter.filter(activeEntities);
     }
 
@@ -212,22 +213,12 @@ public class Manager {
      *
      * @param systemClass The class for the type of system you wish to create
      * @param <T> The class for the type of system you want to create
-     * @param priority The priority that this system takes (the order it executes in). Lower numbers execute first.
      * @return The system you just created
      */
-    public <T extends System> T createSystem(Class<T> systemClass, int priority) {
+    public <T extends System> T createSystem(Class<T> systemClass) {
         try {
             T system = ClassUtils.createInstance(systemClass);
             systems.put(systemClass, system);
-            system.setManager(this);
-            system.setPriority(priority);
-            systems = systems.entrySet().stream()
-                    .sorted(Map.Entry.comparingByValue())
-                    .collect(Collectors.toMap(
-                            Map.Entry::getKey,
-                            Map.Entry::getValue,
-                            (oldValue, newValue) -> oldValue, LinkedHashMap::new
-                    ));
             return system;
         } catch (ReflectionException e) {
             throw new RuntimeException(e);
@@ -235,29 +226,10 @@ public class Manager {
     }
 
     /**
-     * Creates and registers a system of class type specified
-     *
-     * @param systemClass The class for the type of system you wish to create
-     * @param <T> The class for the type of system you want to create
-     * @return The system you just created
+     * @param systemClass The class which represents which system we want to retrieve
+     * @return the instance in this manager of the requested system
      */
-    public <T extends System> T createSystem(Class<T> systemClass) {
-        return createSystem(systemClass, 1);
-    }
-
-    /**
-     * updates all {@link System}s in this manager in order of their priority
-     * @param deltaTime the amount of time in milliseconds that has passed since the last update
-     * @param systems the list of systems you wish to update with this call. Some systems need to update every frame
-     *               others only every tick, so this allows you to only update the systems when they need to be updated,
-     *               no need to update all systems at once.
-     */
-    @SafeVarargs
-    public final void update(float deltaTime, Class<? extends System>... systems) {
-        if (systems.length < 1) Log.warn("Tried to update 0 systems with update call, specify systems you want to update");
-        this.systems.values().stream()
-                .filter(system1 -> Arrays.stream(systems).toList().contains(system1.getClass()))
-                //.sorted(System::compareTo)
-                .forEach(system2 -> system2.update(deltaTime));
+    public System getSystem(Class<? extends System> systemClass) {
+        return systems.get(systemClass);
     }
 }

--- a/src/main/java/com/terminalvelocitycabbage/engine/ecs/Manager.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/ecs/Manager.java
@@ -201,6 +201,7 @@ public class Manager {
      * @param id the UUID of this entity (you can use UUID.fromString() to get this if you only have a string)
      * @return the entity requested or null
      */
+    //TODO add cache for entities often retrieved by UUID, I expect that some entities like windows may be gotten this way often and not via a filter
     public Entity getEntityWithID(UUID id) {
         for (Entity entity : activeEntities) {
             if (entity.getID().equals(id)) return entity;

--- a/src/main/java/com/terminalvelocitycabbage/engine/ecs/Routine.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/ecs/Routine.java
@@ -1,0 +1,73 @@
+package com.terminalvelocitycabbage.engine.ecs;
+
+import com.terminalvelocitycabbage.engine.debug.Log;
+import com.terminalvelocitycabbage.engine.registry.Identifier;
+import com.terminalvelocitycabbage.engine.util.MutableInstant;
+import com.terminalvelocitycabbage.engine.util.Toggle;
+import com.terminalvelocitycabbage.engine.util.touples.Quartet;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Routine {
+
+    //This Map stores data about this managed system including:
+    // - If it's enabled
+    // - When it was last executed (for use in calculating deltaTime)
+    // - The Class which defines this System's Logic
+    // - The ComponentFilter which this system will operate on the current matching entities with
+    Map<Identifier, Quartet<Toggle, MutableInstant, Class<? extends System>, ComponentFilter>> filteredSystems;
+
+    private Routine(Map<Identifier, Quartet<Toggle, MutableInstant, Class<? extends System>, ComponentFilter>> managedSystems) {
+        this.filteredSystems = managedSystems;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public void update(Manager manager) {
+        Log.info("routine update");
+        filteredSystems.forEach((id, quartet) -> {
+            if (!quartet.getValue0().getStatus()) return;
+            manager.getSystem(quartet.getValue2()).update(manager.getMatchingEntities(quartet.getValue3()), quartet.getValue1().getDeltaTime());
+            quartet.getValue1().now();
+        });
+    }
+
+    public void pauseSystem(Identifier systemIdentifier) {
+        filteredSystems.get(systemIdentifier).getValue0().disable();
+    }
+
+    public void resumeSystem(Identifier systemIdentifier) {
+        filteredSystems.get(systemIdentifier).getValue0().enable();
+    }
+
+    public static class Builder {
+
+        Map<Identifier, Quartet<Toggle, MutableInstant, Class<? extends System>, ComponentFilter>> systems = new HashMap();
+
+        public Builder addNode(Identifier nodeIdentifier, Class<? extends System> system) {
+            return addNode(nodeIdentifier, system, null, true);
+        }
+
+        public Builder addNode(Identifier nodeIdentifier, Class<? extends System> system, ComponentFilter componentFilter) {
+            return addNode(nodeIdentifier, system, componentFilter, true);
+        }
+
+        public Builder addNode(Identifier nodeIdentifier, Class<? extends System> system, ComponentFilter componentFilter, boolean automaticallyEnable) {
+            if (systems.containsKey(nodeIdentifier)) {
+                Log.crash("Could not add system node " + nodeIdentifier + " to Routine",
+                        new RuntimeException("node " + nodeIdentifier + " already exists on this Routine."));
+            }
+            systems.put(nodeIdentifier, new Quartet<>(new Toggle(automaticallyEnable), MutableInstant.ofNow(), system, componentFilter));
+            return this;
+        }
+
+        public Routine build() {
+            return new Routine(systems);
+        }
+
+    }
+
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/ecs/System.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/ecs/System.java
@@ -4,68 +4,16 @@ import java.util.List;
 
 /**
  * A system that operates on any family of components. Should be extended into a useful system then added to your
- * {@link Manager} with {@link Manager#createSystem(Class)} to operate on the filtered entities which are retrieved in
- * the user specified {@link System#getEntities()} method using an {@link ComponentFilter}.
+ * {@link Manager} with {@link Manager#createSystem(Class)} to operate on the filtered entities which are retrieved
+ * using an {@link ComponentFilter}.
  */
-public abstract class System implements Comparable<System> {
-
-    //The manager of this system
-    private Manager manager;
-    //The priority of this system, lower numbers are executed first
-    private int priority;
-    //Whether this system is currently processing
-    private boolean processing;
+public abstract class System {
 
     protected System() { }
 
     /**
-     * @return a list of entities that match the requirements of this entity
+     * @param entities The list of entities that were passed to this system filtered by the Repeater's filter
+     * @param deltaTime
      */
-    public abstract List<Entity> getEntities();
-
-    /**
-     * @param deltaTime the amount of time in milliseconds passed since the last update
-     */
-    public abstract void update(float deltaTime);
-
-    /**
-     * @return the priority of this system
-     */
-    public int getPriority() {
-        return priority;
-    }
-
-    /**
-     * @param priority an int to replace this systems current priority
-     */
-    public void setPriority(int priority) {
-        this.priority = priority;
-    }
-
-    /**
-     * @return a boolean representing whether this system is currently being processed
-     */
-    public boolean isProcessing() {
-        return processing;
-    }
-
-    /**
-     * @param processing a boolean to represent the new current state of this system
-     */
-    public void setProcessing(boolean processing) {
-        this.processing = processing;
-    }
-
-    public Manager getManager() {
-        return manager;
-    }
-
-    protected void setManager(Manager manager) {
-        this.manager = manager;
-    }
-
-    @Override
-    public int compareTo(System system) {
-        return this.priority - system.priority;
-    }
+    public abstract void update(List<Entity> entities, float deltaTime);
 }

--- a/src/main/java/com/terminalvelocitycabbage/engine/scheduler/Scheduler.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/scheduler/Scheduler.java
@@ -103,6 +103,7 @@ public class Scheduler {
      * @param task the task to be added to the scheduler
      * @param previousReturn the return value of the previous run task
      */
+    //TODO Replace adding a reference of the task object with scheduling a class that extends task to disallow adding the same task twice (it will error if this happens, but re-using a task should be allowed)
     private void scheduleTask(Task task, Object previousReturn) {
         if (getTask(task.identifier()).isPresent()) {
             Log.error("Tried to schedule task of same identifier: " + task.identifier().toString());

--- a/src/main/java/com/terminalvelocitycabbage/engine/scheduler/Scheduler.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/scheduler/Scheduler.java
@@ -1,0 +1,134 @@
+package com.terminalvelocitycabbage.engine.scheduler;
+
+import com.terminalvelocitycabbage.engine.debug.Log;
+import com.terminalvelocitycabbage.engine.registry.Identifier;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public class Scheduler {
+
+    //Stores all tasks that need to be added to the taskList.
+    //Allow tasks to be scheduled by other tasks without concurrent modification exceptions.
+    private final List<Task> taskQueue;
+    //The current task list that is being executed
+    private final List<Task> taskList;
+    //The list of tasks that need to be removed, empty expect turing task processing
+    private final List<Task> toRemove;
+
+    public Scheduler() {
+        taskList = new ArrayList<>();
+        toRemove = new ArrayList<>();
+        taskQueue = new ArrayList<>();
+    }
+
+    /**
+     * To be called every game tick, processes all the task queues and processes all tasks.
+     */
+    public void tick() {
+
+        //Add tasks scheduled for execution last tick and reset the queue for this tick
+        taskList.addAll(taskQueue);
+        taskQueue.clear();
+
+        //Those tasks marked for removal with subsequent tasks need those to be scheduled for this run
+        taskList.forEach(task -> {
+            long l = task.getLock().readLock();
+            if (task.remove()) {
+                if (task.hasSubsequentTasks()) {
+                    task.subsequentTasks().forEach((task1) -> scheduleTask(task1, task.context().value()));
+                }
+                toRemove.add(task);
+            }
+            task.getLock().unlockRead(l);
+        });
+
+        //Remove tasks that need to be removed and reset list for next tick
+        taskList.removeAll(toRemove);
+        toRemove.clear();
+
+        //Process all the tasks
+        taskList.forEach(task -> {
+            //Some tasks like async tasks might get called more than once if we don't track their status
+            long l = task.getLock().readLock();
+            if (task.running() || task.remove()) {
+                task.getLock().unlockRead(l);
+                return;
+            }
+
+            task.getLock().unlockRead(l);
+            //Check that the tasks here are initialized and error if not
+            if (!task.initialized()) Log.crash("Task not initialized error", new IllegalStateException("Schedulers can only execute initialized tasks"));
+            //Skip this task if it's delayed and not time to execute yet
+            if (task.delay() && task.executeTime() > System.currentTimeMillis()) return;
+            //Run the consumer
+            if (task.repeat()) {
+                if (System.currentTimeMillis() - task.lastExecuteTimeMillis() >= task.repeatInterval()) task.execute();
+            } else {
+                if (task.async()) {
+                    CompletableFuture.supplyAsync(task::context)
+                            .thenAcceptAsync(task.getAndMarkConsumerRunning())
+                            .thenRunAsync(task::markRemove);
+                } else {
+                    task.execute();
+                }
+            }
+            //If this is not a task marked at an interval we need to not run it next time, so mark for removal
+            if (!task.repeat() && !task.running()) task.markRemove();
+        });
+
+        taskQueue.forEach(task -> Log.info(task.identifier().toString()));
+    }
+
+    /**
+     * Schedules a given task for execution upon this scheduler's tick method being called if the conditions
+     * for execution are met by the executor
+     *
+     * @param task the task to be added to the scheduler
+     */
+    public void scheduleTask(Task task) {
+        if (getTask(task.identifier()).isPresent()) {
+            Log.error("Tried to schedule task of same identifier: " + task.identifier().toString());
+            return;
+        }
+        taskQueue.add(task.init());
+    }
+
+    /**
+     * Schedules a given task for execution upon this scheduler's tick method being called if the conditions
+     * for execution are met by the executor
+     *
+     * @param task the task to be added to the scheduler
+     * @param previousReturn the return value of the previous run task
+     */
+    private void scheduleTask(Task task, Object previousReturn) {
+        if (getTask(task.identifier()).isPresent()) {
+            Log.error("Tried to schedule task of same identifier: " + task.identifier().toString());
+            return;
+        }
+        taskQueue.add(task.init(previousReturn));
+    }
+
+    /**
+     * Gets a task by Identifier if it exists on this scheduler
+     *
+     * @param identifier The identifier of the task which you hope to get
+     * @return an Optional of type Task object scheduled in this scheduler with a matching identifier
+     */
+    public Optional<Task> getTask(Identifier identifier) {
+        for (Task task : taskList) {
+            if (task.identifier().equals(identifier)) {
+                return Optional.of(task);
+            }
+        }
+        for (Task task : taskQueue) {
+            if (task.identifier().equals(identifier)) {
+                return Optional.of(task);
+            }
+        }
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/scheduler/Task.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/scheduler/Task.java
@@ -1,0 +1,155 @@
+package com.terminalvelocitycabbage.engine.scheduler;
+
+import com.terminalvelocitycabbage.engine.registry.Identifier;
+
+import java.util.List;
+import java.util.concurrent.locks.StampedLock;
+import java.util.function.Consumer;
+
+public final class Task {
+
+    private final StampedLock lock = new StampedLock();
+    private boolean initialized;
+    private final Identifier identifier;
+    private final Consumer<TaskContext> consumer;
+    private volatile boolean complete;
+    private volatile boolean remove;
+    private final boolean repeat;
+    private final long repeatInterval; //In millis
+    private long lastExecuteTimeMillis;
+    private boolean delay;
+    private final long delayTime; //In millis
+    private long executeTime;
+    private final boolean async;
+    private volatile boolean running;
+    private final TaskContext context;
+    private final List<Task> subsequentTasks;
+
+    public Task(Identifier identifier, Consumer<TaskContext> consumer, boolean repeat, long repeatInterval, boolean delay, long delayInMillis, boolean async, List<Task> subsequentTasks) {
+        this.identifier = identifier;
+        this.consumer = consumer;
+        this.remove = false;
+        this.repeat = repeat;
+        this.repeatInterval = repeatInterval;
+        this.delay = delay;
+        this.delayTime = delayInMillis;
+        this.async = async;
+        this.running = false;
+        this.context = new TaskContext(this);
+        this.subsequentTasks = subsequentTasks;
+    }
+
+    //Used to set times for execute and resets this task to default status in case of re-use (not advised, but allowed)
+    public Task init() {
+        if (delay) executeTime = System.currentTimeMillis() + delayTime;
+        if (repeat) lastExecuteTimeMillis = System.currentTimeMillis() - repeatInterval;
+
+        long l = lock.writeLock();
+        complete = false;
+        remove = false;
+        running = false;
+        lock.unlockWrite(l);
+
+        initialized = true;
+        return this;
+    }
+
+    //Used to set times for execute and such with a previous return value in context
+    public Task init(Object previousReturn) {
+        this.context.previousReturnValue = previousReturn;
+        return init();
+    }
+
+    public Identifier identifier() {
+        return identifier;
+    }
+
+    public Consumer<TaskContext> consumer() {
+        return consumer;
+    }
+
+    public Consumer<TaskContext> getAndMarkConsumerRunning() {
+        long l = lock.writeLock();
+        markRunning();
+        lock.unlockWrite(l);
+        return consumer;
+    }
+
+    public long lastExecuteTimeMillis() {
+        return lastExecuteTimeMillis;
+    }
+
+    public void execute() {
+        consumer().accept(this.context());
+        lastExecuteTimeMillis = System.currentTimeMillis();
+    }
+
+    public boolean remove() {
+        return remove;
+    }
+
+    public void markRemove() {
+        long l = lock.writeLock();
+        remove = true;
+        running = false;
+        lock.unlockWrite(l);
+    }
+
+    public boolean repeat() {
+        return repeat;
+    }
+
+    public long repeatInterval() {
+        return repeatInterval;
+    }
+
+    public boolean delay() {
+        return delay;
+    }
+
+    public long executeTime() {
+        return executeTime;
+    }
+
+    public boolean initialized() {
+        return initialized;
+    }
+
+    public boolean async() {
+        return async;
+    }
+
+    public void markRunning() {
+        this.running = true;
+    }
+
+    public boolean running() {
+        return running;
+    }
+
+    public TaskContext context() {
+        return this.context;
+    }
+
+    public boolean complete() {
+        return complete;
+    }
+
+    public boolean hasSubsequentTasks() {
+        return !subsequentTasks.isEmpty();
+    }
+
+    public List<Task> subsequentTasks() {
+        return subsequentTasks;
+    }
+
+    public StampedLock getLock() {
+        return lock;
+    }
+
+    public void markComplete() {
+        long l = lock.writeLock();
+        complete = true;
+        lock.unlockWrite(l);
+    }
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/scheduler/TaskBuilder.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/scheduler/TaskBuilder.java
@@ -5,6 +5,7 @@ import com.terminalvelocitycabbage.engine.registry.Identifier;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -26,42 +27,88 @@ public class TaskBuilder {
         subsequentTasks = new ArrayList<>();
     }
 
+    /**
+     * Starts a new Task Builder for configuring a new task
+     * @return A new instance of a TaskBuilder
+     */
     public static TaskBuilder builder() {
         return new TaskBuilder();
     }
 
-    public TaskBuilder identifier(Identifier identifier) {
-        this.identifier = identifier;
+    /**
+     * Assigns a unique identifier to this task from a namespace and task name, it then appends a uuid to the end
+     * of the task name to make sure it is unique.
+     * @param namespace The namespace of the identifier being created. Usually the ID of your game or mod
+     * @param taskName The name which identifies this task
+     * @return this TaskBuilder
+     */
+    public TaskBuilder identifier(String namespace, String taskName) {
+        this.identifier = new Identifier(namespace, taskName + "[" + UUID.randomUUID() + "]");
         return this;
     }
 
+    /**
+     * Assigns the consumer which will be carried out by the scheduler when this task is executed.
+     * @param taskConsumer a consumer that defines the action that this task is intended to complete
+     * @return this TaskBuilder
+     */
     public TaskBuilder executes(Consumer<TaskContext> taskConsumer) {
         consumer = taskConsumer;
         return this;
     }
 
+    /**
+     * Defines the repeat interval for this task if desired
+     * @param interval the interval (as an integer) for which this task will be repeated.
+     * @param timeUnit the time unit for the interval specified
+     * @return this TaskBuilder
+     */
     public TaskBuilder repeat(int interval, TimeUnit timeUnit) {
         repeat = true;
         repeatInterval = TimeUnit.MILLISECONDS.convert(interval, timeUnit);
         return this;
     }
 
+    /**
+     * Defines the time between when this task is added to the scheduler and when it should execute
+     * @param interval the interval (as an integer) by which this task will be delayed by.
+     * @param timeUnit the time unit for the interval specified
+     * @return this TaskBuilder
+     */
     public TaskBuilder delay(int interval, TimeUnit timeUnit) {
         delay = true;
         delayInMillis = TimeUnit.MILLISECONDS.convert(interval, timeUnit);
         return this;
     }
 
+    /**
+     * configures this task to be run async (non-blocking).
+     * @return this TaskBuilder
+     */
     public TaskBuilder async() {
         async = true;
         return this;
     }
 
+    /**
+     * Allows you to specify another task to be executed after this task, data can be passed between tasks by using the
+     * TaskContext on a task accessible by the tasks' consumer. see {@link TaskContext} for more information.
+     * @param task the task which will be scheduled after this task
+     * @return this TaskBuilder
+     */
     public TaskBuilder then(Task task) {
         subsequentTasks.add(task);
         return this;
     }
 
+    /**
+     * Builds this TaskBuilder config into a new Task.
+     * A Task must have 2 things at least:
+     *  - An Identifier
+     *  - A Consumer
+     *  All other nodes of this builder are optional.
+     * @return A new Task based on the configuration done by this builder
+     */
     public Task build() {
 
         if (identifier == null) {

--- a/src/main/java/com/terminalvelocitycabbage/engine/scheduler/TaskBuilder.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/scheduler/TaskBuilder.java
@@ -1,0 +1,82 @@
+package com.terminalvelocitycabbage.engine.scheduler;
+
+import com.terminalvelocitycabbage.engine.debug.Log;
+import com.terminalvelocitycabbage.engine.registry.Identifier;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+public class TaskBuilder {
+
+    private Identifier identifier;
+    private Consumer<TaskContext> consumer;
+    private boolean repeat;
+    private long repeatInterval;
+    private boolean delay;
+    private long delayInMillis;
+    private boolean async;
+    private final List<Task> subsequentTasks;
+
+    private TaskBuilder() {
+        repeat = false;
+        delay = false;
+        async = false;
+        subsequentTasks = new ArrayList<>();
+    }
+
+    public static TaskBuilder builder() {
+        return new TaskBuilder();
+    }
+
+    public TaskBuilder identifier(Identifier identifier) {
+        this.identifier = identifier;
+        return this;
+    }
+
+    public TaskBuilder executes(Consumer<TaskContext> taskConsumer) {
+        consumer = taskConsumer;
+        return this;
+    }
+
+    public TaskBuilder repeat(int interval, TimeUnit timeUnit) {
+        repeat = true;
+        repeatInterval = TimeUnit.MILLISECONDS.convert(interval, timeUnit);
+        return this;
+    }
+
+    public TaskBuilder delay(int interval, TimeUnit timeUnit) {
+        delay = true;
+        delayInMillis = TimeUnit.MILLISECONDS.convert(interval, timeUnit);
+        return this;
+    }
+
+    public TaskBuilder async() {
+        async = true;
+        return this;
+    }
+
+    public TaskBuilder then(Task task) {
+        subsequentTasks.add(task);
+        return this;
+    }
+
+    public Task build() {
+
+        if (identifier == null) {
+            Log.crash("Tried to create a non-identifiable task",
+                    "A task must have an identifier associated with it",
+                    "make sure to call .identifier(...) on your TaskBuilder chain before calling .build()",
+                    new IllegalStateException("tried to build task with no identifier"));
+        }
+
+        if (consumer == null) {
+            Log.crash("Tried to create a taskless task",
+                    "A task must have an .executes() node associated with it",
+                    new IllegalStateException("tried to build task with no identifier"));
+        }
+
+        return new Task(identifier, consumer, repeat, repeatInterval, delay, delayInMillis, async, subsequentTasks);
+    }
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/scheduler/TaskContext.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/scheduler/TaskContext.java
@@ -1,0 +1,37 @@
+package com.terminalvelocitycabbage.engine.scheduler;
+
+public class TaskContext {
+
+    Task task;
+    Object previousReturnValue;
+    Object value;
+
+    public TaskContext(Task task) {
+        this.task = task;
+    }
+
+    public TaskContext(Task task, Object previousReturnValue) {
+        this.task = task;
+        this.previousReturnValue = previousReturnValue;
+    }
+
+    public Task task() {
+        return task;
+    }
+
+    public Object previous() {
+        return previousReturnValue;
+    }
+
+    public Object value() {
+        return value;
+    }
+
+    public void setReturn(Object value) {
+        this.value = value;
+    }
+
+    public boolean hasPrevious() {
+        return previousReturnValue != null;
+    }
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/scheduler/TaskContext.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/scheduler/TaskContext.java
@@ -49,4 +49,11 @@ public class TaskContext {
     public boolean hasPrevious() {
         return previousReturnValue != null;
     }
+
+    /**
+     * @return the value of this contexts return
+     */
+    public Object returnValue() {
+        return returnValue;
+    }
 }

--- a/src/main/java/com/terminalvelocitycabbage/engine/scheduler/TaskContext.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/scheduler/TaskContext.java
@@ -1,10 +1,15 @@
 package com.terminalvelocitycabbage.engine.scheduler;
 
+/**
+ * A TaskContext is how you pass data between stages of a schedule task. It allows you to pass a return value as an
+ * object on to subsequent tasks. This is especially useful for I/O operations. You can schedule an async task to
+ * fetch some data and then return it to another blocking task once it's done reading.
+ */
 public class TaskContext {
 
     Task task;
     Object previousReturnValue;
-    Object value;
+    Object returnValue;
 
     public TaskContext(Task task) {
         this.task = task;
@@ -15,22 +20,32 @@ public class TaskContext {
         this.previousReturnValue = previousReturnValue;
     }
 
+    /**
+     * @return the {@link Task} which this TaskContext belongs to
+     */
     public Task task() {
         return task;
     }
 
-    public Object previous() {
+    /**
+     * @return an arbitrary object that represents whatever the parent to this task set as it's return value.
+     * This task should know how to cast it into usable data
+     */
+    public Object previousReturn() {
         return previousReturnValue;
     }
 
-    public Object value() {
-        return value;
-    }
-
+    /**
+     * @param value An object which will be passed on to the children of this task (tasks defined in the
+     * {@link TaskBuilder#then(Task)} node of the builder that built this task) within the child tasks' TaskContext.
+     */
     public void setReturn(Object value) {
-        this.value = value;
+        this.returnValue = value;
     }
 
+    /**
+     * @return true if this task has a parent task.
+     */
     public boolean hasPrevious() {
         return previousReturnValue != null;
     }

--- a/src/main/java/com/terminalvelocitycabbage/engine/server/ServerBase.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/server/ServerBase.java
@@ -3,6 +3,7 @@ package com.terminalvelocitycabbage.engine.server;
 import com.github.simplenet.Server;
 import com.terminalvelocitycabbage.engine.Entrypoint;
 import com.terminalvelocitycabbage.engine.debug.Log;
+import com.terminalvelocitycabbage.engine.ecs.Manager;
 import com.terminalvelocitycabbage.engine.event.EventDispatcher;
 import com.terminalvelocitycabbage.engine.filesystem.GameFileSystem;
 import com.terminalvelocitycabbage.engine.mod.Mod;
@@ -40,6 +41,7 @@ public abstract class ServerBase extends Entrypoint implements NetworkedSide {
     private EventDispatcher eventDispatcher;
     private ModManager modManager;
     private Registry<Mod> modRegistry;
+    private Manager manager;
 
     //Resources Stuff
     private GameFileSystem fileSystem;
@@ -52,6 +54,7 @@ public abstract class ServerBase extends Entrypoint implements NetworkedSide {
         eventDispatcher.addPublisher(getNamespace(), this);
         modManager = new ModManager();
         modRegistry = new Registry<>(null);
+        manager = new Manager();
         fileSystem = new GameFileSystem();
     }
 
@@ -175,6 +178,10 @@ public abstract class ServerBase extends Entrypoint implements NetworkedSide {
 
     public ModManager getModManager() {
         return modManager;
+    }
+
+    public Manager getManager() {
+        return manager;
     }
 
     public Registry<Mod> getModRegistry() {

--- a/src/main/java/com/terminalvelocitycabbage/engine/server/ServerBase.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/server/ServerBase.java
@@ -13,6 +13,7 @@ import com.terminalvelocitycabbage.engine.networking.PacketRegistry;
 import com.terminalvelocitycabbage.engine.networking.SerializablePacket;
 import com.terminalvelocitycabbage.engine.networking.Side;
 import com.terminalvelocitycabbage.engine.registry.Registry;
+import com.terminalvelocitycabbage.engine.scheduler.Scheduler;
 import com.terminalvelocitycabbage.engine.util.TickManager;
 import com.terminalvelocitycabbage.templates.events.ServerLifecycleEvent;
 
@@ -42,6 +43,7 @@ public abstract class ServerBase extends Entrypoint implements NetworkedSide {
     private ModManager modManager;
     private Registry<Mod> modRegistry;
     private Manager manager;
+    private Scheduler scheduler;
 
     //Resources Stuff
     private GameFileSystem fileSystem;
@@ -151,7 +153,9 @@ public abstract class ServerBase extends Entrypoint implements NetworkedSide {
     /**
      * The logic to be executed when this Server updates
      */
-    public abstract void tick();
+    public void tick() {
+        getScheduler().tick();
+    }
 
     /**
      * Marks this server as ready to stop
@@ -182,6 +186,10 @@ public abstract class ServerBase extends Entrypoint implements NetworkedSide {
 
     public Manager getManager() {
         return manager;
+    }
+
+    public Scheduler getScheduler() {
+        return scheduler;
     }
 
     public Registry<Mod> getModRegistry() {

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/ClassUtils.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/ClassUtils.java
@@ -33,6 +33,14 @@ public class ClassUtils {
 		}
 	}
 
+	public static <T> T createInstance(Class<T> clazz, Object param) throws ReflectionException {
+		try {
+			return clazz.getDeclaredConstructor(param.getClass()).newInstance(param);
+		} catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+			throw new ReflectionException(e, "Could not instantiate instance of class: " + clazz.getName());
+		}
+	}
+
 	public static Constructor getConstructor(Class clazz) throws ReflectionException {
 		try {
 			return clazz.getConstructor();

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/MutableInstant.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/MutableInstant.java
@@ -1,0 +1,43 @@
+package com.terminalvelocitycabbage.engine.util;
+
+/**
+ * A utility class to track and update a set instant in time, useful for calculating deltaTime and storing it for
+ * later use.
+ */
+public class MutableInstant {
+
+    long instant;
+
+    private MutableInstant(long instant) {
+        this.instant = instant;
+    }
+
+    /**
+     * @return a new instance of {@link MutableInstant} with the current time
+     */
+    public static MutableInstant ofNow() {
+        return new MutableInstant(System.currentTimeMillis());
+    }
+
+    /**
+     * @return The currently stored instant in time
+     */
+    public long getTimeInMillis() {
+        return instant;
+    }
+
+    /**
+     * Updates the stored instant to the current time.
+     */
+    public void now() {
+        this.instant = System.currentTimeMillis();
+    }
+
+    /**
+     * @return The deltaTime between now and the stored instant
+     */
+    public long getDeltaTime() {
+        return System.currentTimeMillis() - instant;
+    }
+
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/Toggle.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/Toggle.java
@@ -1,0 +1,56 @@
+package com.terminalvelocitycabbage.engine.util;
+
+/**
+ * A simple class to represent a toggleable yes/no status
+ */
+public class Toggle {
+
+    boolean status;
+
+    public Toggle() {
+        this(true);
+    }
+
+    /**
+     * @param status The initial status of this Toggle
+     */
+    public Toggle(boolean status) {
+        this.status = status;
+    }
+
+    /**
+     * @return The status of this toggle
+     */
+    public boolean getStatus() {
+        return status;
+    }
+
+    /**
+     * Set the status of this toggle to the
+     * @param status boolean status
+     */
+    public void setStatus(boolean status) {
+        this.status = status;
+    }
+
+    /**
+     * Toggle this toggle to it's opposite state
+     */
+    public void toggle() {
+        setStatus(!getStatus());
+    }
+
+    /**
+     * Sets the status of this toggle to enabled
+     */
+    public void enable() {
+        setStatus(true);
+    }
+
+    /**
+     * Sets the status of this toggle to disabled
+     */
+    public void disable() {
+        setStatus(false);
+    }
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Decade.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Decade.java
@@ -1,0 +1,15 @@
+package com.terminalvelocitycabbage.engine.util.touples;
+
+public class Decade<A, B, C, D, E, F, G, H, I, J> extends Ennead<A, B, C, D, E, F, G, H, I> {
+
+    private final J value9;
+
+    public Decade(A value0, B value1, C value2, D value3, E value4, F value5, G value6, H value7, I value8, J value9) {
+        super(value0, value1, value2, value3, value4, value5, value6, value7, value8);
+        this.value9 = value9;
+    }
+
+    public J getValue9() {
+        return value9;
+    }
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Ennead.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Ennead.java
@@ -1,0 +1,15 @@
+package com.terminalvelocitycabbage.engine.util.touples;
+
+public class Ennead<A, B, C, D, E, F, G, H, I> extends Octet<A, B, C, D, E, F, G, H> {
+
+    private final I value8;
+
+    public Ennead(A value0, B value1, C value2, D value3, E value4, F value5, G value6, H value7, I value8) {
+        super(value0, value1, value2, value3, value4, value5, value6, value7);
+        this.value8 = value8;
+    }
+
+    public I getValue8() {
+        return value8;
+    }
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Octet.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Octet.java
@@ -1,0 +1,15 @@
+package com.terminalvelocitycabbage.engine.util.touples;
+
+public class Octet<A, B, C, D, E, F, G, H> extends Septet<A, B, C, D, E, F, G> {
+
+    private final H value7;
+
+    public Octet(A value0, B value1, C value2, D value3, E value4, F value5, G value6, H value7) {
+        super(value0, value1, value2, value3, value4, value5, value6);
+        this.value7 = value7;
+    }
+
+    public H getValue7() {
+        return value7;
+    }
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Pair.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Pair.java
@@ -1,17 +1,12 @@
 package com.terminalvelocitycabbage.engine.util.touples;
 
-public class Pair<A, B> {
+public class Pair<A, B> extends Unit<A> {
 
-    private final A value0;
     private final B value1;
 
     public Pair(A value0, B value1) {
-        this.value0 = value0;
+        super(value0);
         this.value1 = value1;
-    }
-
-    public A getValue0() {
-        return value0;
     }
 
     public B getValue1() {

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Pair.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Pair.java
@@ -1,0 +1,20 @@
+package com.terminalvelocitycabbage.engine.util.touples;
+
+public class Pair<A, B> {
+
+    private final A value0;
+    private final B value1;
+
+    public Pair(A value0, B value1) {
+        this.value0 = value0;
+        this.value1 = value1;
+    }
+
+    public A getValue0() {
+        return value0;
+    }
+
+    public B getValue1() {
+        return value1;
+    }
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Quartet.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Quartet.java
@@ -1,0 +1,15 @@
+package com.terminalvelocitycabbage.engine.util.touples;
+
+public class Quartet<A, B, C, D> extends Triplet<A, B, C> {
+
+    private final D value3;
+
+    public Quartet(A value0, B value1, C value2, D value3) {
+        super(value0, value1, value2);
+        this.value3 = value3;
+    }
+
+    public D getValue3() {
+        return value3;
+    }
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Quintet.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Quintet.java
@@ -1,0 +1,15 @@
+package com.terminalvelocitycabbage.engine.util.touples;
+
+public class Quintet<A, B, C, D, E> extends Quartet<A, B, C, D> {
+
+    private final E value4;
+
+    public Quintet(A value0, B value1, C value2, D value3, E value4) {
+        super(value0, value1, value2, value3);
+        this.value4 = value4;
+    }
+
+    public E getValue4() {
+        return value4;
+    }
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Septet.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Septet.java
@@ -1,0 +1,15 @@
+package com.terminalvelocitycabbage.engine.util.touples;
+
+public class Septet<A, B, C, D, E, F, G> extends Sextet<A, B, C, D, E, F> {
+
+    private final G value6;
+
+    public Septet(A value0, B value1, C value2, D value3, E value4, F value5, G value6) {
+        super(value0, value1, value2, value3, value4, value5);
+        this.value6 = value6;
+    }
+
+    public G getValue6() {
+        return value6;
+    }
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Sextet.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Sextet.java
@@ -1,0 +1,15 @@
+package com.terminalvelocitycabbage.engine.util.touples;
+
+public class Sextet<A, B, C, D, E, F> extends Quintet<A, B, C, D, E> {
+
+    private final F value5;
+
+    public Sextet(A value0, B value1, C value2, D value3, E value4, F value5) {
+        super(value0, value1, value2, value3, value4);
+        this.value5 = value5;
+    }
+
+    public F getValue5() {
+        return value5;
+    }
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Triplet.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Triplet.java
@@ -1,0 +1,15 @@
+package com.terminalvelocitycabbage.engine.util.touples;
+
+public class Triplet<A, B, C> extends Pair<A, B> {
+
+    private final C value2;
+
+    public Triplet(A value0, B value1, C value2) {
+        super(value0, value1);
+        this.value2 = value2;
+    }
+
+    public C getValue2() {
+        return value2;
+    }
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Unit.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/util/touples/Unit.java
@@ -1,0 +1,15 @@
+package com.terminalvelocitycabbage.engine.util.touples;
+
+public class Unit<A> {
+
+    private final A value0;
+
+    public Unit(A value0) {
+        this.value0 = value0;
+    }
+
+    public A getValue0() {
+        return value0;
+    }
+
+}


### PR DESCRIPTION
This PR intends to do a few things:
1. Add a Scheduler
2. Strip Entity Managers of their System update logic in favor of a new Routine Class
3. Introduce a new Render Graph System for dividing a renderer into steps
4. Make Manager Thread Safe