### PR TITLE
Simplify bedrock loader

### DIFF
--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/animation/Animation.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/animation/Animation.java
@@ -110,9 +110,9 @@ public class Animation {
     }
 
     //Bone name, transformations
-    Map<String, Triplet<Vector3f, Vector3f, Vector3f>> currentTransformations = new HashMap<>();
+    Map<String, TransformationSnapshot> currentTransformations = new HashMap<>();
     List<Pair<Float, Keyframe>> progressKeyframes = new ArrayList<>();
-    public Map<String, Triplet<Vector3f, Vector3f, Vector3f>> getCurrentTransformations() {
+    public Map<String, TransformationSnapshot> getCurrentTransformations() {
         currentTransformations.clear();
         progressKeyframes.clear();
         for (String boneName : keyframes.keySet()) {
@@ -150,7 +150,7 @@ public class Animation {
         return (currentTime - keyframe.startTime) / (keyframe.endTime - keyframe.startTime);
     }
 
-    Triplet<Vector3f, Vector3f, Vector3f> getCurrentTransforms(List<Pair<Float, Keyframe>> keyframes) {
+    TransformationSnapshot getCurrentTransforms(List<Pair<Float, Keyframe>> keyframes) {
 
         //combine all keyframe transformations into one
         Vector3f position = new Vector3f();
@@ -167,7 +167,7 @@ public class Animation {
             }
         }
 
-        return new Triplet<>(position, rotation, scale);
+        return new TransformationSnapshot(position, rotation, scale);
     }
 
     void interpolateComponent(Vector3f transformation, float progress, Keyframe keyframe) {

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/animation/AnimationController.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/animation/AnimationController.java
@@ -45,10 +45,10 @@ public class AnimationController {
             //Get this animation's transformations add them together
             animation.getCurrentTransformations().forEach(
                     (boneName, boneTransformation) -> {
-                        var index = bonesMap.get(boneName).getBoneIndex();
-                        boneTransformations.get(index).position().add(boneTransformation.getValue0());
-                        boneTransformations.get(index).rotation().add(boneTransformation.getValue1());
-                        boneTransformations.get(index).scale().mul(boneTransformation.getValue2());
+                        var transformation = boneTransformations.get(bonesMap.get(boneName).getBoneIndex());
+                        transformation.position().add(boneTransformation.position());
+                        transformation.rotation().add(boneTransformation.rotation());
+                        transformation.scale().mul(boneTransformation.scale());
                     }
             );
         }
@@ -67,8 +67,8 @@ public class AnimationController {
             );
             boneTransformationMatrices.get(index)
                     .identity()
-                    .translationRotateScale(boneTransformation.position(), rotation, boneTransformation.scale())
-                    .translate(bone.getOffset());
+                    .translationRotateScale(boneTransformation.position(), rotation, boneTransformation.scale());
+                    //.translate(bone.getOffset());
         }
     }
 

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/animation/TransformationSnapshot.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/animation/TransformationSnapshot.java
@@ -1,0 +1,6 @@
+package com.terminalvelocitycabbage.engine.client.renderer.animation;
+
+import org.joml.Vector3f;
+
+public record TransformationSnapshot(Vector3f position, Vector3f rotation, Vector3f scale) {
+}

--- a/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/animation/bedrock/BedrockAnimationData.java
+++ b/src/main/java/com/terminalvelocitycabbage/engine/client/renderer/animation/bedrock/BedrockAnimationData.java
@@ -65,7 +65,7 @@ public class BedrockAnimationData {
             convertedAnimations.put(animationName, animation);
         }
 
-        return new AnimationController(convertedAnimations, model.getBoneIndexMap());
+        return new AnimationController(convertedAnimations, model.getBones());
     }
 
     public record AnimationData (
@@ -173,7 +173,7 @@ public class BedrockAnimationData {
                     previousKeyframeEndTransformation = previousKeyframe.getEndTransformation();
                     previousKeyframeEndTime = previousKeyframe.getEndTime();
                 }
-                var endTimeMillis = Float.parseFloat(endTimeSeconds) * 1000;
+                var endTimeMillis = Float.parseFloat(endTimeSeconds) * 1000f;
 
                 //Create the keyframes
                 if (keyframeConfigOrTransformation.toString().startsWith("[")) { //linear is simplified out in bbmodel


### PR DESCRIPTION
This aims to simplify the bedrock loader by not keeping the origin and rotation point in the model so that animations can be applied directly. The model object should store this so that the animation controller can re-apply them each frame when animating, but it halves the number of transformations by doing it this way (in theory). This is a branch instead of a commit so that we can compare and sus out potential breakages from the feature branch.
